### PR TITLE
Add path information to the window title

### DIFF
--- a/main.c
+++ b/main.c
@@ -314,6 +314,7 @@ void load_image(int new)
 	close_info();
 	open_info();
 	arl_setup(&arl, files[fileidx].path);
+	win_set_title(&win, files[fileidx].path);
 
 	if (img.multi.cnt > 0 && img.multi.animate)
 		set_timeout(animate, img.multi.frames[img.multi.sel].delay, true);
@@ -939,6 +940,7 @@ int main(int argc, char **argv)
 		load_image(fileidx);
 	}
 	win_open(&win);
+	win_set_title(&win, files[fileidx].path);
 	win_set_cursor(&win, CURSOR_WATCH);
 
 	atexit(cleanup);

--- a/sxiv.1
+++ b/sxiv.1
@@ -387,6 +387,21 @@ Color of the window foreground and bar background
 .B font
 Name of Xft bar font
 .TP
+.B titlePrefix
+Any string literal to be used as the window title prefix.
+.TP
+.B titleSuffix
+The format of the window title suffix.
+
+.EX
+    Value  Format
+    0      Basename of file
+    1      Basename of directory
+    2      Full path to file
+    3      Full path to directory
+    4      Empty string
+.EE
+.TP
 Please see xrdb(1) on how to change them.
 .SH STATUS BAR
 The information displayed on the left side of the status bar can be replaced

--- a/sxiv.h
+++ b/sxiv.h
@@ -115,6 +115,16 @@ typedef enum {
 	FF_TN_INIT = 4
 } fileflags_t;
 
+typedef enum {
+	BASE_CFILE,
+	BASE_CDIR,
+	CFILE,
+	CDIR,
+	EMPTY,
+
+	SUFFIXMODE_COUNT,
+} suffixmode_t;
+
 typedef struct {
 	const char *name; /* as given by user */
 	const char *path; /* always absolute */
@@ -409,6 +419,10 @@ struct win {
 
 	XftColor bg;
 	XftColor fg;
+
+	suffixmode_t suffixmode;
+	const char   *prefix;
+	const char   *suffix;
 
 	int x;
 	int y;

--- a/thumbs.c
+++ b/thumbs.c
@@ -35,6 +35,7 @@ void exif_auto_orientate(const fileinfo_t*);
 Imlib_Image img_open(const fileinfo_t*);
 
 static char *cache_dir;
+extern const int fileidx;
 
 char* tns_cache_filepath(const char *filepath)
 {
@@ -531,6 +532,7 @@ bool tns_move_selection(tns_t *tns, direction_t dir, int cnt)
 		if (!tns->dirty)
 			tns_highlight(tns, *tns->sel, true);
 	}
+	win_set_title(tns->win, tns->files[fileidx].path);
 	return *tns->sel != old;
 }
 

--- a/window.c
+++ b/window.c
@@ -120,7 +120,7 @@ void win_init(win_t *win)
 	f = win_res(db, RES_CLASS ".font", "monospace-8");
 	win_init_font(e, f);
 
-	win->prefix = win_res(db, RES_CLASS ".titlePrefix", "sxiv - ");
+	win->prefix = win_res(db, RES_CLASS ".titlePrefix", "sxiv");
 	win->suffixmode = strtol(win_res(db, RES_CLASS ".titleSuffix", "0"),
 	                         NULL, 10) % SUFFIXMODE_COUNT;
 
@@ -478,8 +478,9 @@ void win_set_title(win_t *win, const char *path)
 
 	/* Some ancient WM's that don't comply to EMWH (e.g. mwm) only use WM_NAME for
 	 * the window title, which is set by XStoreName below. */
-	title = emalloc(strlen(win->prefix) + strlen(win->suffix) + 1);
-	(void)sprintf(title, "%s%s", win->prefix, win->suffix);
+	size_t suffixLen = strlen(win->suffix);
+	title = emalloc(strlen(win->prefix) + suffixLen + 1);
+	(void)sprintf(title, "%s%s%s", win->prefix, (suffixLen == 0) ? "" : " - ", win->suffix);
 	XChangeProperty(win->env.dpy, win->xwin, atoms[ATOM__NET_WM_NAME],
 	                XInternAtom(win->env.dpy, "UTF8_STRING", False), 8,
 	                PropModeReplace, (unsigned char *)title, strlen(title));


### PR DESCRIPTION
The title is broken in a literal prefix and in a path suffix.
Both can be configured via X-resources.

https://github.com/muennich/sxiv/pull/453#issue-906753721
For those who use window managers (e.g. dwm, icewm) that show window titles, it may be useful to show the current file name in the title. This PR breaks the title in a string literal prefix and a suffix that shows a file path component, both X-resources configurable.

```
sxiv - fileInView.png
^^^^^^^
prefix ^^^^^^^^^^^^^^
           suffix
```

The suffix can be the filename, its full path, its directory name, its directory full path, or, to keep backwards compatibility, nothing. Please see the manual for more detailed information.