### PR TITLE
Load all images on directory

### DIFF
--- a/main.c
+++ b/main.c
@@ -923,7 +923,7 @@ int main(int argc, char **argv)
 		error(EXIT_FAILURE, 0, "No valid image file given, aborting");
 
 	filecnt = fileidx;
-	fileidx = 0;
+	fileidx = options->startnum < filecnt ? options->startnum : 0;
 	if (options->loaddir) {
 		if (savedname == NULL) {
 			savedname = emalloc(sizeof(""));
@@ -936,8 +936,6 @@ int main(int argc, char **argv)
 				}
 			}
 		}
-	} else {
-		fileidx = options->startnum < filecnt ? options->startnum : 0;
 	}
 	free(savedname);
 	if (options->loaddir)

--- a/options.c
+++ b/options.c
@@ -30,7 +30,7 @@ const opt_t *options = (const opt_t*) &_options;
 
 void print_usage(void)
 {
-	printf("usage: sxiv [-abcfhiopqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
+	printf("usage: sxiv [-abcdfhiopqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
 	       "[-g GEOMETRY] [-N NAME] [-n NUM] [-S DELAY] [-s MODE] [-z ZOOM] "
 	       "[-F FILE] FILES...\n");
 }
@@ -54,6 +54,7 @@ void parse_options(int argc, char **argv)
 	_options.recursive = false;
 	_options.startnum = 0;
 	_options.startfile = NULL;
+	_options.loaddir = false;
 
 	_options.scalemode = SCALE_DOWN;
 	_options.zoom = 1.0;
@@ -73,7 +74,7 @@ void parse_options(int argc, char **argv)
 	_options.clean_cache = false;
 	_options.private_mode = false;
 
-	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:F:N:opqrS:s:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "A:abcde:fG:g:hin:F:N:opqrS:s:tvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -92,6 +93,9 @@ void parse_options(int argc, char **argv)
 				break;
 			case 'c':
 				_options.clean_cache = true;
+				break;
+			case 'd':
+				_options.loaddir = true;
 				break;
 			case 'e':
 				n = strtol(optarg, &end, 0);

--- a/sxiv.1
+++ b/sxiv.1
@@ -3,7 +3,7 @@
 sxiv \- Simple X Image Viewer
 .SH SYNOPSIS
 .B sxiv
-.RB [ \-abcfhiopqrtvZ ]
+.RB [ \-abcdfhiopqrtvZ ]
 .RB [ \-A
 .IR FRAMERATE ]
 .RB [ \-e
@@ -48,6 +48,9 @@ Do not show info bar on bottom of window.
 .TP
 .B \-c
 Remove all orphaned cache files from the thumbnail cache directory and exit.
+.TP
+.B \-d
+Open image and all images on it's parent dir
 .TP
 .BI "\-e " WID
 Embed sxiv's window into window whose ID is

--- a/sxiv.1
+++ b/sxiv.1
@@ -73,7 +73,8 @@ Set the resource name of sxiv's X window to NAME.
 Start at picture number NUM.
 .TP
 .BI "\-F " FILE
-Start at picture file FILE.
+Start at picture file FILE. May conflict with 
+.B \-d
 .TP
 .B \-h
 Print brief usage information to standard output and exit.

--- a/sxiv.desktop
+++ b/sxiv.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=sxiv
 GenericName=Image Viewer
-Exec=sxiv -a %F
+Exec=sxiv -ad %F
 MimeType=image/bmp;image/gif;image/jpeg;image/jpg;image/png;image/tiff;image/x-bmp;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-tga;image/x-xpixmap;image/webp;image/svg+xml;
 NoDisplay=true
 Icon=sxiv

--- a/sxiv.h
+++ b/sxiv.h
@@ -292,6 +292,7 @@ struct opt {
 	int filecnt;
 	int startnum;
 	char *startfile;
+	bool loaddir;
 
 	/* image: */
 	scalemode_t scalemode;


### PR DESCRIPTION
This adds the option (with ``-d``) to load all images on the parent directory of current image.